### PR TITLE
fix for github security

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@picode/fbx": "^0.0.2",
-    "deferred-regl": "git://github.com/kevzettler/deferred-regl#a6dbc9dd188f433a026e70223f8d2fe945fcb377",
+    "deferred-regl": "https://github.com/kevzettler/deferred-regl#a6dbc9dd188f433a026e70223f8d2fe945fcb377",
     "fbjs": "^3.0.0",
     "fbx-parser": "^2.1.3",
     "geom-triangulate": "^1.0.1",


### PR DESCRIPTION
This is a fix as mentioned here: https://github.com/heroku/heroku-buildpack-nodejs/issues/959

for GitHub security changes as released here: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Thank you for this package,